### PR TITLE
Fixed wrong mapping with newline

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2568,9 +2568,8 @@
             } else {
                 SourceNode = global.sourceMap.SourceNode;
             }
-            // convert nodes to a SourceNodes in order to work with sourceMaps
+            // convert newline to a SourceNode in order to work with sourceMaps
             newline = toSourceNodeWhenNeeded(newline);
-            indent = toSourceNodeWhenNeeded(indent);
         }
 
         result = generateInternal(node);

--- a/escodegen.js
+++ b/escodegen.js
@@ -2568,6 +2568,9 @@
             } else {
                 SourceNode = global.sourceMap.SourceNode;
             }
+            // convert nodes to a SourceNodes in order to work with sourceMaps
+            newline = toSourceNodeWhenNeeded(newline);
+            indent = toSourceNodeWhenNeeded(indent);
         }
 
         result = generateInternal(node);


### PR DESCRIPTION
When generating source map, newline was having a bad mapping. 
Now it converts the node in order to have no mapping.